### PR TITLE
Added conditional result messages

### DIFF
--- a/FinderKeeper/Assets/Scenes/End.unity
+++ b/FinderKeeper/Assets/Scenes/End.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657856, g: 0.49641234, b: 0.57481724, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -366,6 +366,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   scoreText: {fileID: 1861053012}
+  messageText: {fileID: 1295545371}
 --- !u!1 &933985259
 GameObject:
   m_ObjectHideFlags: 0
@@ -591,7 +592,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Thanks for playing Finders Seekers
+  m_Text: Thanks for playing Finder Keeper
 --- !u!222 &1111617130
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -654,7 +655,7 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 54
+    m_FontSize: 55
     m_FontStyle: 1
     m_BestFit: 0
     m_MinSize: 0
@@ -850,7 +851,7 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 75
+    m_FontSize: 73
     m_FontStyle: 1
     m_BestFit: 0
     m_MinSize: 0

--- a/FinderKeeper/Assets/Scripts/Results.cs
+++ b/FinderKeeper/Assets/Scripts/Results.cs
@@ -4,16 +4,30 @@ using UnityEngine;
 using UnityEngine.UI;
 
 public class Results : MonoBehaviour {
-    public Text scoreText;
-    private string scoreOutput = "You found: ";
+	[SerializeField]
+    Text scoreText;
+
+	[SerializeField]
+	Text messageText;
 
 	// Use this for initialization
 	void Start () {
-		scoreText.text =scoreOutput + EndGame.finalScore;
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
+		scoreText.text = "You found: " + EndGame.finalScore;
+
+		switch (EndGame.finalScore)
+		{
+			case "5/5":
+				messageText.text = "Impressive!";
+				break;
+			case "4/5":
+				messageText.text = "So close!";
+				break;
+			case "3/5":
+				messageText.text = "Well done!";
+				break;	
+			default:
+				messageText.text = "Better luck next time!";
+				break;
+		}
 	}
 }


### PR DESCRIPTION
# Changes

- Added different messages to be displayed on the results screen depending on the number of items collected

# Screenshots

<img width="267" alt="screen shot 2018-09-26 at 7 22 12 pm" src="https://user-images.githubusercontent.com/17773547/46070803-ffd81400-c1c1-11e8-99fb-c9390e6e6f43.png">
Message for 0 through 2 items collected

<img width="267" alt="screen shot 2018-09-26 at 7 23 24 pm" src="https://user-images.githubusercontent.com/17773547/46070832-154d3e00-c1c2-11e8-9a2e-8a57299e5118.png">
Message for 3 items collected

<img width="266" alt="screen shot 2018-09-26 at 7 23 45 pm" src="https://user-images.githubusercontent.com/17773547/46070861-1f6f3c80-c1c2-11e8-9923-6110edad0ef6.png">
Message for 4 items collected

<img width="266" alt="screen shot 2018-09-26 at 7 24 01 pm" src="https://user-images.githubusercontent.com/17773547/46070876-25651d80-c1c2-11e8-872d-5ee14d2e81d5.png">
Message for 5 items collected