### PR TITLE
Added overview map to map scene

### DIFF
--- a/FinderKeeper/Assets/Material/Blue.mat
+++ b/FinderKeeper/Assets/Material/Blue.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Blue
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 3
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 0, g: 0.4764049, b: 1, a: 0.47058824}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/FinderKeeper/Assets/Material/Blue.mat.meta
+++ b/FinderKeeper/Assets/Material/Blue.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bb876988ff9f4aa9b23cbda9cbbabc8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FinderKeeper/Assets/Models/Orb/VisibilityController.prefab
+++ b/FinderKeeper/Assets/Models/Orb/VisibilityController.prefab
@@ -195,7 +195,7 @@ ParticleSystem:
   simulationSpeed: 1
   stopAction: 0
   looping: 1
-  prewarm: 0
+  prewarm: 1
   playOnAwake: 1
   useUnscaledTime: 0
   autoRandomSeed: 1

--- a/FinderKeeper/Assets/Prefabs/Player.prefab
+++ b/FinderKeeper/Assets/Prefabs/Player.prefab
@@ -384,7 +384,7 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
   m_Materials:
-  - {fileID: 2100000, guid: caa6c6f6f7879034992a27a6bc3794fd, type: 2}
+  - {fileID: 2100000, guid: 0bb876988ff9f4aa9b23cbda9cbbabc8, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -557,8 +557,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 061d2afb48ace4fd19611279b6cf732f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _useDeviceOrientation: 0
+  _subtractUserHeading: 0
   _rotationFollowFactor: 2
   _rotateZ: 0
+  _useNegativeAngle: 0
   _useTransformLocationProvider: 0
 --- !u!114 &114224615066493946
 MonoBehaviour:

--- a/FinderKeeper/Assets/Scenes/map.unity
+++ b/FinderKeeper/Assets/Scenes/map.unity
@@ -826,6 +826,11 @@ Prefab:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: c60242da976d7f24f8b8a1bc4cea7170, type: 2}
+    - target: {fileID: 198280288110941628, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0,
+        type: 2}
+      propertyPath: prewarm
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
   m_IsPrefabParent: 0
@@ -3549,7 +3554,7 @@ Transform:
   - {fileID: 48971992}
   - {fileID: 1459868929}
   m_Father: {fileID: 1483012083}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &937329417
 MonoBehaviour:
@@ -3648,6 +3653,141 @@ Transform:
   - {fileID: 746676567}
   m_Father: {fileID: 46839028}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1006689813
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1144877731728236, guid: 35ce2bb4caba9434db5e656796b632b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1006689816}
+  - component: {fileID: 1006689815}
+  m_Layer: 0
+  m_Name: OverviewMap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1006689815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114276132085450664, guid: 35ce2bb4caba9434db5e656796b632b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1006689813}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd961b1c9541a4cee99686069ecce852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _initializeOnStart: 0
+  _options:
+    locationOptions:
+      latitudeLongitude: 37.784179, -122.401583
+      zoom: 16
+    extentOptions:
+      extentType: 0
+      cameraBoundsOptions:
+        camera: {fileID: 1248989438}
+        visibleBuffer: 0
+        disposeBuffer: 0
+      rangeAroundCenterOptions:
+        west: 1
+        north: 1
+        east: 1
+        south: 1
+      rangeAroundTransformOptions:
+        targetTransform: {fileID: 0}
+        visibleBuffer: 0
+        disposeBuffer: 0
+    placementOptions:
+      placementType: 1
+      snapMapToZero: 0
+    scalingOptions:
+      scalingType: 1
+      unityTileSize: 100
+    loadingTexture: {fileID: 2800000, guid: e2896a92727704803a9c422b043eae89, type: 3}
+    tileMaterial: {fileID: 0}
+  _imagery:
+    _layerProperty:
+      sourceType: 2
+      sourceOptions:
+        isActive: 1
+        layerSource:
+          Name: Streets
+          Id: mapbox://styles/mapbox/dark-v9
+          Modified: 
+          UserName: 
+      rasterOptions:
+        useRetina: 1
+        useCompression: 0
+        useMipMap: 1
+  _terrain:
+    _layerProperty:
+      sourceType: 0
+      sourceOptions:
+        isActive: 1
+        layerSource:
+          Name: 
+          Id: mapbox.terrain-rgb
+          Modified: 
+          UserName: 
+      elevationLayerType: 0
+      requiredOptions:
+        addCollider: 0
+        exaggerationFactor: 1
+      modificationOptions:
+        sampleCount: 10
+        useRelativeHeight: 1
+        earthRadius: 1000
+      unityLayerOptions:
+        addToLayer: 0
+        layerId: 0
+      sideWallOptions:
+        isActive: 0
+        wallHeight: 10
+        wallMaterial: {fileID: 0}
+  _vectorData:
+    _layerProperty:
+      tileJsonData:
+        tileJSONLoaded: 0
+        LayerDisplayNames: []
+      _sourceType: 1
+      sourceOptions:
+        isActive: 1
+        layerSource:
+          Name: Mapbox Terrain
+          Id: mapbox.3d-buildings,mapbox.mapbox-streets-v7
+          Modified: 
+          UserName: 
+      useOptimizedStyle: 0
+      optimizedStyle:
+        Name: 
+        Id: 
+        Modified: 
+        UserName: 
+      performanceOptions:
+        isEnabled: 1
+        entityPerCoroutine: 20
+      vectorSubLayers: []
+      locationPrefabList: []
+  _tileProvider: {fileID: 0}
+--- !u!4 &1006689816
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4771038816137298, guid: 35ce2bb4caba9434db5e656796b632b1,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1006689813}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1483012083}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1012281225
 GameObject:
@@ -4560,9 +4700,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c5f0e7ef902fc4eefbb7d53b7a997fce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  IsometricCamera: {fileID: 1738812505}
-  ThirdPersonCamera: {fileID: 1248989438}
-  isIsoCamera: 1
+  _isometricCamera: {fileID: 1738812505}
+  _thirdPersonCamera: {fileID: 1248989438}
+  _radarPulse: {fileID: 1012281225}
 --- !u!114 &1352142565
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5011,6 +5151,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1483012083}
   - component: {fileID: 1483012082}
+  - component: {fileID: 1483012084}
   m_Layer: 0
   m_Name: LocationBasedGame
   m_TagString: Untagged
@@ -5042,10 +5183,32 @@ Transform:
   m_Children:
   - {fileID: 1352142558}
   - {fileID: 1771452849}
+  - {fileID: 1006689816}
   - {fileID: 937329416}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1483012084
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1483012081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9831ee22e37c4381a2af820aca79988, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mapGameObject: {fileID: 1771452846}
+  _overviewMapGameObject: {fileID: 1006689813}
+  _playerGameObject: {fileID: 1352142557}
+  _radarPulse: {fileID: 1012281225}
+  _map: {fileID: 1771452847}
+  _overviewMap: {fileID: 1006689815}
+  _markerPrefab: {fileID: 1572807047655010, guid: dc045e62d23a829479b958da9344af88,
+    type: 2}
+  _playerPrefab: {fileID: 100004, guid: cdc93de93f2f11e48a70a0446b5a5557, type: 3}
+  _markerSpawnScale: 12
 --- !u!1 &1491010567
 GameObject:
   m_ObjectHideFlags: 0
@@ -6149,13 +6312,35 @@ MonoBehaviour:
     _layerProperty:
       tileJsonData:
         tileJSONLoaded: 0
-        LayerDisplayNames: []
+        LayerDisplayNames:
+        - admin
+        - aeroway
+        - airport_label
+        - barrier_line
+        - building
+        - country_label
+        - housenum_label
+        - landuse
+        - landuse_overlay
+        - marine_label
+        - motorway_junction
+        - mountain_peak_label
+        - place_label
+        - poi_label
+        - rail_station_label
+        - road
+        - road_label
+        - state_label
+        - water
+        - water_label
+        - waterway
+        - waterway_label
       _sourceType: 1
       sourceOptions:
         isActive: 1
         layerSource:
           Name: Mapbox Terrain
-          Id: mapbox.3d-buildings,mapbox.mapbox-streets-v7
+          Id: mapbox.mapbox-streets-v7
           Modified: 
           UserName: 
       useOptimizedStyle: 0
@@ -6208,7 +6393,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf44a65d5a57342b3acbce3ae17842a9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _locationBasedGame: {fileID: 1483012081}
+  _mapGameObject: {fileID: 1771452846}
   _map: {fileID: 1771452847}
   _locationStrings:
   - -37.807395, 144.986678
@@ -6216,7 +6401,6 @@ MonoBehaviour:
   - -37.807999, 144.987240
   - -37.808024, 144.986382
   - -37.808914, 144.987723
-  - -37.847971, 144.729233
   _spawnScale: 1.5
   _markerPrefab: {fileID: 1961207376309816, guid: 32f43cd74ac333842801bc372d4db9d4,
     type: 2}
@@ -6296,9 +6480,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 242394799}
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1483012084}
+        m_MethodName: ToggleOverviewMap
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/FinderKeeper/Assets/Scripts/CameraSwap.cs
+++ b/FinderKeeper/Assets/Scripts/CameraSwap.cs
@@ -2,24 +2,29 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CameraSwap : MonoBehaviour
- {
-     public Camera IsometricCamera, ThirdPersonCamera;
-     public bool isIsoCamera = true;
+public class CameraSwap : MonoBehaviour {
+    [SerializeField]
+    Camera _isometricCamera;
 
-     public void Swap()
-     {
-         isIsoCamera = !isIsoCamera;
-         IsometricCamera.gameObject.SetActive(isIsoCamera);
-         ThirdPersonCamera.gameObject.SetActive(!isIsoCamera);
+    [SerializeField]
+    Camera _thirdPersonCamera;
 
-         GameObject radar = GameObject.FindGameObjectWithTag("RadarPulse");
-         var position = radar.transform.localPosition;
-         if (isIsoCamera) {
-             position.z = 0;
-         } else {
-             position.z = -12;
-         }
-         radar.transform.localPosition = position;
-     }
- }
+    [SerializeField]
+    GameObject _radarPulse;
+
+    bool _isIsoCamera = true;
+
+    public void Swap() {
+        _isIsoCamera = !_isIsoCamera;
+        _isometricCamera.gameObject.SetActive(_isIsoCamera);
+        _thirdPersonCamera.gameObject.SetActive(!_isIsoCamera);
+
+        var position = _radarPulse.transform.localPosition;
+        if (_isIsoCamera) {
+            position.z = 0;
+        } else {
+            position.z = -12;
+        }
+        _radarPulse.transform.localPosition = position;
+    }
+}

--- a/FinderKeeper/Assets/Scripts/OverviewMap.cs
+++ b/FinderKeeper/Assets/Scripts/OverviewMap.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Mapbox.Unity;
+using Mapbox.Unity.Map;
+using Mapbox.Unity.Utilities;
+using Mapbox.Utils;
+using Mapbox.Map;
+
+public class OverviewMap : MonoBehaviour {
+
+    [SerializeField]
+    GameObject _mapGameObject;
+
+    [SerializeField]
+    GameObject _overviewMapGameObject;
+
+    [SerializeField]
+    GameObject _playerGameObject;
+
+    [SerializeField]
+    GameObject _radarPulse;
+
+    [SerializeField]
+    AbstractMap _map;
+
+    [SerializeField]
+    AbstractMap _overviewMap;
+
+    [SerializeField]
+    GameObject _markerPrefab;
+
+    [SerializeField]
+    GameObject _playerPrefab;
+
+    [SerializeField]
+    float _markerSpawnScale;
+
+    Vector2d[] _locations;
+
+    List<GameObject> _spawnedObjects;
+
+    GameObject _playerInstance;
+
+    WaitForSeconds _wait;
+
+    bool _overviewIsActive = false;
+
+    public void ToggleOverviewMap () {
+        if (_overviewIsActive) {
+            Destroy(_playerInstance);
+
+            _overviewMapGameObject.SetActive(false);
+            _mapGameObject.SetActive(true);
+
+            _playerGameObject.transform.localScale = new Vector3(1, 1, 1);
+            _radarPulse.SetActive(true);
+
+            _overviewIsActive = false;
+        } else {
+            _playerGameObject.transform.localScale = new Vector3(0, 1, 1);
+            _radarPulse.SetActive(false);
+
+            _playerInstance = Instantiate(_playerPrefab);
+            _playerInstance.transform.SetParent(_overviewMapGameObject.transform);
+            _playerInstance.transform.localPosition = _overviewMap.GeoToWorldPosition(_map.CenterLatitudeLongitude, true);
+           
+            _overviewMapGameObject.SetActive(true);
+            _mapGameObject.SetActive(false);
+
+            _overviewIsActive = true;
+        }
+	}
+
+	// Use this for initialization
+	void Start () {
+        StartCoroutine(Initialize());
+	}
+
+    IEnumerator Initialize () {
+        yield return new WaitForSeconds(1);
+
+        InitializeObjects();
+
+        InitializeOverviewMap();
+    }
+
+	private void InitializeObjects () {
+        string[] locationStrings = new string[0];
+		SpawnOnMap spawnScript = _map.GetComponent(typeof(SpawnOnMap)) as SpawnOnMap;
+
+		if (spawnScript != null) {
+		    locationStrings = spawnScript._locationStrings;
+        }
+        _locations = new Vector2d[locationStrings.Length];
+        
+        _spawnedObjects = new List<GameObject>();
+        for (int i = 0; i < locationStrings.Length; i++) {
+            _locations[i] = Conversions.StringToLatLon(locationStrings[i]);         
+
+            Vector2d randPoint = new Vector2d(CalculateRandomXOffset(_locations[i]), CalculateRandomYOffset(_locations[i]));
+            
+            var instance = Instantiate(_markerPrefab);
+            instance.transform.SetParent(_overviewMapGameObject.transform);
+            instance.transform.localPosition = _map.GeoToWorldPosition(randPoint, true);
+            instance.transform.localScale = new Vector3(_markerSpawnScale, _markerSpawnScale, _markerSpawnScale);
+            _spawnedObjects.Add(instance);
+        }
+    }
+
+    private void InitializeOverviewMap () {
+        _overviewMap.Initialize(CalculateCentroid(_locations), _map.AbsoluteZoom);
+        _overviewMap.TileProvider.UpdateTileExtent();
+        _overviewMapGameObject.SetActive(false);
+    }
+
+    private Vector2d CalculateCentroid (Vector2d[] points) {
+        Vector2d centroid = Vector2d.zero;
+        var numPoints = points.Length;
+
+        foreach(Vector2d point in points) {
+            centroid += point;
+        }
+
+        centroid /= numPoints;
+
+        return centroid;
+    }
+
+    private double CalculateRandomXOffset (Vector2d point) {
+        double randX = 0.00;
+        if (Random.value > 0.5) {
+            randX = point.x + ((double)Random.Range(0, 11) / 111111);
+        } else {
+            randX = point.x - ((double)Random.Range(0, 11) / 111111);
+        }
+        return randX;
+    }
+
+    private double CalculateRandomYOffset (Vector2d point) {
+        var randY = 0.0;
+        if (Random.value > 0.5) {
+            randY = point.y + (Random.Range(0, 11) / (111111 * Mathf.Cos((float)(point.x * (Mathf.PI / 180)))));
+        } else {
+            randY = point.y - (Random.Range(0, 11) / (111111 * Mathf.Cos((float)(point.x * (Mathf.PI / 180)))));
+        }
+        return randY;
+    }
+	
+	// Update is called once per frame
+	private void Update () {
+        if ((_spawnedObjects != null) && (_overviewMapGameObject.activeSelf)) {
+            int count = _spawnedObjects.Count;
+            for (int i = 0; i < count; i++)
+            {
+                var spawnedObject = _spawnedObjects[i];
+                var location = _locations[i];
+                spawnedObject.transform.localPosition = _overviewMap.GeoToWorldPosition(location, true);
+                spawnedObject.transform.localScale = new Vector3(_markerSpawnScale, _markerSpawnScale, _markerSpawnScale);
+            }
+        }
+	}
+}

--- a/FinderKeeper/Assets/Scripts/OverviewMap.cs.meta
+++ b/FinderKeeper/Assets/Scripts/OverviewMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9831ee22e37c4381a2af820aca79988
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FinderKeeper/Assets/Scripts/SpawnOnMap.cs
+++ b/FinderKeeper/Assets/Scripts/SpawnOnMap.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 public class SpawnOnMap : MonoBehaviour
 {
     [SerializeField]
-    GameObject _locationBasedGame;
+    GameObject _mapGameObject;
 
     [SerializeField]
     AbstractMap _map;
@@ -36,7 +36,7 @@ public class SpawnOnMap : MonoBehaviour
             var locationString = _locationStrings[i];
             _locations[i] = Conversions.StringToLatLon(locationString);
             var instance = Instantiate(_markerPrefab);
-            instance.transform.SetParent(_locationBasedGame.transform);
+            instance.transform.SetParent(_mapGameObject.transform);
             instance.transform.localPosition = _map.GeoToWorldPosition(_locations[i], true);
             instance.transform.localScale = new Vector3(_spawnScale, _spawnScale, _spawnScale);
             _spawnedObjects.Add(instance);


### PR DESCRIPTION
# Changes
- Implemented overview map which shows approximately where each item can be found (Currently toggled from the hamburger menu button that is to be replaced with a map icon).

# Screenshots
- Isometric views:
<img width="267" alt="screen shot 2018-09-30 at 11 44 36 pm" src="https://user-images.githubusercontent.com/17773547/46258334-2a043b80-c50c-11e8-814c-e079b9659047.png">
<img width="267" alt="screen shot 2018-09-30 at 11 44 48 pm" src="https://user-images.githubusercontent.com/17773547/46258335-2c669580-c50c-11e8-866c-fc1f6066758c.png">

- Third person views:
<img width="266" alt="screen shot 2018-09-30 at 11 45 07 pm" src="https://user-images.githubusercontent.com/17773547/46258338-3ab4b180-c50c-11e8-8847-04aa88536d06.png">
<img width="268" alt="screen shot 2018-09-30 at 11 45 26 pm" src="https://user-images.githubusercontent.com/17773547/46258339-3c7e7500-c50c-11e8-9c3f-21d0a673d667.png">

