### PR TITLE
Fix overview map images and radar size

### DIFF
--- a/FinderKeeper/Assets/Material/UI.mat
+++ b/FinderKeeper/Assets/Material/UI.mat
@@ -73,5 +73,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 0.9528302, g: 0.4179868, b: 0.4179868, a: 0.078431375}
+    - _Color: {r: 1, g: 1, b: 1, a: 0.078431375}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/FinderKeeper/Assets/Scenes/map.unity
+++ b/FinderKeeper/Assets/Scenes/map.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657856, g: 0.49641234, b: 0.57481724, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -857,6 +857,38 @@ Prefab:
         type: 2}
       propertyPath: prewarm
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198280288110941628, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0,
+        type: 2}
+      propertyPath: SizeBySpeedModule.enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198280288110941628, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0,
+        type: 2}
+      propertyPath: SizeModule.enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 198280288110941628, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0,
+        type: 2}
+      propertyPath: lengthInSec
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 198280288110941628, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0,
+        type: 2}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
+      propertyPath: m_LocalScale.x
+      value: 17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
+      propertyPath: m_LocalScale.y
+      value: 17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
+      propertyPath: m_LocalScale.z
+      value: 17.5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
@@ -4803,6 +4835,33 @@ Prefab:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: 77227c1b7a7dc414abfe774072973a3e, type: 2}
+    - target: {fileID: 198537462924421500, guid: 0cbf921c24e7fa74ca4ba04b04079e09,
+        type: 2}
+      propertyPath: ShapeModule.enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198537462924421500, guid: 0cbf921c24e7fa74ca4ba04b04079e09,
+        type: 2}
+      propertyPath: lengthInSec
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 198537462924421500, guid: 0cbf921c24e7fa74ca4ba04b04079e09,
+        type: 2}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
+      propertyPath: m_LocalScale.x
+      value: 17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
+      propertyPath: m_LocalScale.y
+      value: 17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
+      propertyPath: m_LocalScale.z
+      value: 17.5
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
   m_IsPrefabParent: 0

--- a/FinderKeeper/Assets/Scenes/map.unity
+++ b/FinderKeeper/Assets/Scenes/map.unity
@@ -467,8 +467,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 1967406053}
-  - {fileID: 814800039}
+  - {fileID: 523949210}
+  - {fileID: 2060725531}
   m_Father: {fileID: 1006689816}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2026,6 +2026,75 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 468239926}
+--- !u!1 &523949209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 523949210}
+  - component: {fileID: 523949212}
+  - component: {fileID: 523949211}
+  m_Layer: 5
+  m_Name: UpperPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &523949210
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 523949209}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.1313701, y: 1.1313701, z: 1.1313701}
+  m_Children:
+  - {fileID: 1249005353}
+  m_Father: {fileID: 96350818}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.9}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.000030517578, y: 0}
+  m_SizeDelta: {x: -74.314575, y: -11.147156}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &523949211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 523949209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.92549026, g: 0.8000001, b: 0.38431376, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &523949212
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 523949209}
 --- !u!1 &594762924
 GameObject:
   m_ObjectHideFlags: 0
@@ -2565,80 +2634,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 672946432}
---- !u!1 &691661493
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 691661494}
-  - component: {fileID: 691661496}
-  - component: {fileID: 691661495}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &691661494
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 691661493}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1967406053}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.16741912, y: 0.192}
-  m_AnchorMax: {x: 0.8433235, y: 0.808}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &691661495
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 691661493}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.21960786, g: 0.30980393, b: 0.46274513, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 50
-    m_FontStyle: 1
-    m_BestFit: 1
-    m_MinSize: 0
-    m_MaxSize: 245
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Back
---- !u!222 &691661496
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 691661493}
 --- !u!1 &722275309
 GameObject:
   m_ObjectHideFlags: 0
@@ -2957,7 +2952,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &814800039
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2966,15 +2961,15 @@ RectTransform:
   m_GameObject: {fileID: 814800038}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.74218, y: 0.64941, z: 0.92771995}
+  m_LocalScale: {x: 0.6560011, y: 0.5740032, z: 0.81999695}
   m_Children: []
-  m_Father: {fileID: 96350818}
+  m_Father: {fileID: 2060725531}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.82681245, y: 0.019000001}
-  m_AnchorMax: {x: 0.95168746, y: 0.089}
-  m_AnchoredPosition: {x: 0, y: 0.00579834}
-  m_SizeDelta: {x: 27.700012, y: 36.1}
+  m_AnchorMin: {x: 0.837419, y: 0.11657023}
+  m_AnchorMax: {x: 0.92723227, y: 0.88278514}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0.0000038146973}
+  m_SizeDelta: {x: 26.642, y: 48.251}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &814800040
 MonoBehaviour:
@@ -3351,12 +3346,12 @@ MonoBehaviour:
     tileMaterial: {fileID: 0}
   _imagery:
     _layerProperty:
-      sourceType: 2
+      sourceType: 6
       sourceOptions:
         isActive: 1
         layerSource:
           Name: Streets
-          Id: mapbox://styles/mapbox/dark-v9
+          Id: mapbox://styles/xortheus/cjm4zr2oobnek2slf2z9vpjwt
           Modified: 
           UserName: 
       rasterOptions:
@@ -4148,6 +4143,80 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!1 &1249005352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1249005353}
+  - component: {fileID: 1249005355}
+  - component: {fileID: 1249005354}
+  m_Layer: 5
+  m_Name: MapContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1249005353
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249005352}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.80000365, y: 0.7000009, z: 1}
+  m_Children: []
+  m_Father: {fileID: 523949210}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.04550111, y: 0.24042977}
+  m_AnchorMax: {x: 0.952, y: 0.748}
+  m_AnchoredPosition: {x: -0.001373291, y: 0.000034332275}
+  m_SizeDelta: {x: 128.19885, y: 18.458}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1249005354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249005352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18431373, g: 0.227451, b: 0.30588236, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 47
+    m_FontStyle: 1
+    m_BestFit: 1
+    m_MinSize: 0
+    m_MaxSize: 83
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Search These Areas!
+--- !u!222 &1249005355
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249005352}
 --- !u!1 &1352142557
 GameObject:
   m_ObjectHideFlags: 0
@@ -4165,7 +4234,6 @@ GameObject:
   - component: {fileID: 1352142564}
   - component: {fileID: 1352142565}
   - component: {fileID: 1352142566}
-  - component: {fileID: 1352142568}
   - component: {fileID: 1352142561}
   m_Layer: 0
   m_Name: Player
@@ -4231,7 +4299,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb301d66009714d398678cc8297fdacb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _useDeviceOrientation: 0
+  _useDeviceOrientation: 1
   _subtractUserHeading: 0
   _rotationFollowFactor: 1
   _rotateZ: 0
@@ -4324,18 +4392,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
---- !u!114 &1352142568
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1352142557}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8724de7e5ba08874a81094b35e9660b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  menuPanel: {fileID: 0}
 --- !u!1 &1362107563
 GameObject:
   m_ObjectHideFlags: 0
@@ -4728,16 +4784,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a9831ee22e37c4381a2af820aca79988, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _canvas: {fileID: 413035922}
-  _disableOverviewMapButton: {fileID: 1967406052}
-  _currentLocationButton: {fileID: 814800038}
+  _mapCanvas: {fileID: 413035922}
+  _overviewMapCanvas: {fileID: 96350817}
   _mapGameObject: {fileID: 1771452846}
   _overviewMapGameObject: {fileID: 1006689813}
   _playerGameObject: {fileID: 1352142557}
   _radarPulse: {fileID: 1012281225}
   _map: {fileID: 1771452847}
   _overviewMap: {fileID: 1006689815}
-  _markerPrefab: {fileID: 1572807047655010, guid: dc045e62d23a829479b958da9344af88,
+  _markerPrefab: {fileID: 1934693623955548, guid: dc045e62d23a829479b958da9344af88,
     type: 2}
   _playerPrefab: {fileID: 100004, guid: cdc93de93f2f11e48a70a0446b5a5557, type: 3}
   _markerSpawnScale: 12
@@ -6823,7 +6878,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1967406053
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6832,16 +6887,15 @@ RectTransform:
   m_GameObject: {fileID: 1967406052}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.74218, y: 0.64941, z: 0.92772}
-  m_Children:
-  - {fileID: 691661494}
-  m_Father: {fileID: 96350818}
+  m_LocalScale: {x: 0.6560011, y: 0.5740032, z: 0.819997}
+  m_Children: []
+  m_Father: {fileID: 2060725531}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.041687496, y: 0.018000001}
-  m_AnchorMax: {x: 0.28025, y: 0.08129616}
-  m_AnchoredPosition: {x: -0.27001953, y: 0.019958496}
-  m_SizeDelta: {x: 53.229523, y: 34.128326}
+  m_AnchorMin: {x: 0.05923224, y: 0.15200001}
+  m_AnchorMax: {x: 0.13000001, y: 0.77664477}
+  m_AnchoredPosition: {x: 0.00012207031, y: -0.00005340576}
+  m_SizeDelta: {x: 20.992, y: 39.336}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1967406054
 MonoBehaviour:
@@ -6914,7 +6968,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 46b7022372ba2114ea6c7b0cf781ca8b, type: 3}
+  m_Sprite: {fileID: 21300000, guid: d67083fb048e8d445899c48252ed550a, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -7024,6 +7078,113 @@ Transform:
   m_Father: {fileID: 1501138801}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2060725530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2060725531}
+  - component: {fileID: 2060725535}
+  - component: {fileID: 2060725534}
+  - component: {fileID: 2060725533}
+  - component: {fileID: 2060725532}
+  m_Layer: 5
+  m_Name: LowerPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2060725531
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2060725530}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.1313701, y: 1.1313701, z: 1.1313701}
+  m_Children:
+  - {fileID: 1967406053}
+  - {fileID: 814800039}
+  m_Father: {fileID: 96350818}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.1}
+  m_AnchoredPosition: {x: -0.000030517578, y: 0}
+  m_SizeDelta: {x: -74.314575, y: -11.147179}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2060725532
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2060725530}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1254083943, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 0
+  m_AspectRatio: 4.8773007
+--- !u!114 &2060725533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2060725530}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 25
+    m_Right: 25
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 18
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+--- !u!114 &2060725534
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2060725530}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.92549026, g: 0.8000001, b: 0.38431376, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &2060725535
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2060725530}
 --- !u!1 &2073048665
 GameObject:
   m_ObjectHideFlags: 0

--- a/FinderKeeper/Assets/Scripts/DistanceToPlayer.cs
+++ b/FinderKeeper/Assets/Scripts/DistanceToPlayer.cs
@@ -14,7 +14,7 @@ public class DistanceToPlayer : MonoBehaviour {
 	void Update () {
         GameObject player = GameObject.FindGameObjectWithTag("Player");
         float dist = (gameObject.transform.position - player.transform.position).magnitude;
-        if (!ToggleARMode.isARActive && dist < 15.0f)
+        if (!ToggleARMode.isARActive && dist < 7.5f)
         {
             gameObject.transform.GetChild(0).gameObject.SetActive(true);
             gameObject.transform.GetChild(1).gameObject.SetActive(true);
@@ -24,7 +24,6 @@ public class DistanceToPlayer : MonoBehaviour {
             gameObject.transform.GetChild(0).gameObject.SetActive(false);
             gameObject.transform.GetChild(1).gameObject.SetActive(false);
         }
-        //Debug.Log(string.Format("Distance between {0} and {1} is: {2}",gameObject, player, dist));
     }
     
 }

--- a/FinderKeeper/Assets/Scripts/OverviewMap.cs
+++ b/FinderKeeper/Assets/Scripts/OverviewMap.cs
@@ -10,13 +10,10 @@ using Mapbox.Examples;
 
 public class OverviewMap : MonoBehaviour {
     [SerializeField]
-    GameObject _canvas;
+    GameObject _mapCanvas;
 
     [SerializeField]
-    GameObject _disableOverviewMapButton;
-
-    [SerializeField]
-    GameObject _currentLocationButton;
+    GameObject _overviewMapCanvas;
 
     [SerializeField]
     GameObject _mapGameObject;
@@ -69,7 +66,7 @@ public class OverviewMap : MonoBehaviour {
         _playerGameObject.transform.localScale = new Vector3(0, 1, 1);
         _radarPulse.SetActive(false);
 
-        _canvas.SetActive(false);
+        _mapCanvas.SetActive(false);
         
         _mapGameObject.SetActive(false);
 
@@ -78,9 +75,7 @@ public class OverviewMap : MonoBehaviour {
 
         _playerInstance.SetActive(true);
 
-        _disableOverviewMapButton.SetActive(true);
-
-        _currentLocationButton.SetActive(true);
+        _overviewMapCanvas.SetActive(true);
 
         _oldRotationSetting = _rotationScript.isRotatable;
         if (_rotationScript.isRotatable) {
@@ -102,9 +97,7 @@ public class OverviewMap : MonoBehaviour {
             _rotationScript.ToggleRotation();
         }
 
-        _currentLocationButton.SetActive(false);
-
-        _disableOverviewMapButton.SetActive(false);
+        _overviewMapCanvas.SetActive(false);
 
         _playerInstance.SetActive(false);
 
@@ -112,7 +105,7 @@ public class OverviewMap : MonoBehaviour {
 
         _mapGameObject.SetActive(true);
 
-        _canvas.SetActive(true);
+        _mapCanvas.SetActive(true);
 
         _playerGameObject.transform.localScale = new Vector3(1, 1, 1);
         _radarPulse.SetActive(true);


### PR DESCRIPTION
# Changes

## Radar
- Decreased size of radar animation by half
- Decreased the distance player can "see" objects by half

## Overview Map
- Added upper and lower panel to overview map consistent with the UI
- Added some context to the upper panel
- Changed the sphere into a transparent radar image
- Changed the back button image

# Screenshots

## Radar
<img width="266" alt="screen shot 2018-10-05 at 12 46 47 pm" src="https://user-images.githubusercontent.com/17773547/46513662-14d93500-c89d-11e8-85ae-ba53b230958c.png">
Old max

<img width="267" alt="screen shot 2018-10-05 at 12 28 14 pm" src="https://user-images.githubusercontent.com/17773547/46513671-1c004300-c89d-11e8-88af-814f0b811d2f.png">
New max

## Overview Map
<img width="268" alt="screen shot 2018-10-05 at 12 47 01 pm" src="https://user-images.githubusercontent.com/17773547/46513684-291d3200-c89d-11e8-877c-aa760be60ab0.png">
Old map

<img width="268" alt="screen shot 2018-10-05 at 12 40 50 pm" src="https://user-images.githubusercontent.com/17773547/46513699-33d7c700-c89d-11e8-9952-43477ff23dec.png">
New map