### PR TITLE
Changes for Expo

### DIFF
--- a/FinderKeeper/Assets/Scenes/AROverviewMap.unity
+++ b/FinderKeeper/Assets/Scenes/AROverviewMap.unity
@@ -1476,12 +1476,17 @@ Prefab:
     - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
         type: 2}
       propertyPath: _vectorData._layerProperty.locationPrefabList.Array.size
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
         type: 2}
       propertyPath: _vectorData._layerProperty.locationPrefabList.Array.data[0].coordinates.Array.size
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _vectorData._layerProperty.vectorSubLayers.Array.data[0].filterOptions.filters.Array.size
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4580065472578918, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
       propertyPath: m_LocalPosition.x
@@ -1698,6 +1703,26 @@ Prefab:
     - target: {fileID: 1789645920474078, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}
       propertyPath: m_Layer
       value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _vectorData._layerProperty.vectorSubLayers.Array.data[0].filterOptions.filters.Array.data[0].KeyDescription
+      value: Number. Height of building or part of building.
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _vectorData._layerProperty.vectorSubLayers.Array.data[0].filterOptions.filters.Array.data[0].Key
+      value: height
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _vectorData._layerProperty.vectorSubLayers.Array.data[0].filterOptions.filters.Array.data[0].filterOperator
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 114378541491328834, guid: c0ce4c9dacbd84ff09f18011abded7e6,
+        type: 2}
+      propertyPath: _vectorData._layerProperty.vectorSubLayers.Array.data[0].filterOptions.filters.Array.data[0].Min
+      value: 30
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 114949404173606746, guid: c0ce4c9dacbd84ff09f18011abded7e6, type: 2}

--- a/FinderKeeper/Assets/Scenes/map.unity
+++ b/FinderKeeper/Assets/Scenes/map.unity
@@ -563,15 +563,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
       propertyPath: m_LocalScale.x
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
       propertyPath: m_LocalScale.y
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4165213320594474, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
       propertyPath: m_LocalScale.z
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f9bb8fd617c79004c96e5ae8d5b2b8c0, type: 2}
@@ -682,7 +682,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.01677149, y: 0.1804807}
   m_AnchorMax: {x: 0.142, y: 0.84629774}
-  m_AnchoredPosition: {x: 22.330994, y: -0.5000553}
+  m_AnchoredPosition: {x: 22.330994, y: -0.5000534}
   m_SizeDelta: {x: 47.89622, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &338544964
@@ -2982,7 +2982,7 @@ MonoBehaviour:
   _subtractUserHeading: 0
   _rotationFollowFactor: 1
   _rotateZ: 0
-  _useNegativeAngle: 0
+  _useNegativeAngle: 1
   _useTransformLocationProvider: 0
   isRotatable: 1
 --- !u!114 &1352142562
@@ -3476,6 +3476,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a9831ee22e37c4381a2af820aca79988, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _locationProvider: {fileID: 2117919255}
   _mapCanvas: {fileID: 413035922}
   _overviewMapCanvas: {fileID: 96350817}
   _mapGameObject: {fileID: 1771452846}
@@ -3601,15 +3602,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
       propertyPath: m_LocalScale.x
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
       propertyPath: m_LocalScale.y
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4904196409281692, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
       propertyPath: m_LocalScale.z
-      value: 17.5
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 0cbf921c24e7fa74ca4ba04b04079e09, type: 2}
@@ -4619,11 +4620,11 @@ MonoBehaviour:
   _mapGameObject: {fileID: 1771452846}
   _map: {fileID: 1771452847}
   _locationStrings:
-  - -37.807774, 144.986006
-  - -37.807808, 144.986368
-  - -37.807970, 144.986349
-  - -37.807935, 144.985970
-  - -37.807876, 144.986173
+  - -37.822807, 145.038072
+  - -37.822716, 145.038359
+  - -37.822712, 145.038024
+  - -37.822854, 145.038332
+  - -37.822500, 145.038407
   _spawnScale: 1.5
   _markerPrefab: {fileID: 1961207376309816, guid: 32f43cd74ac333842801bc372d4db9d4,
     type: 2}
@@ -5829,9 +5830,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a38712e93231418a84665190b8473d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _desiredAccuracyInMeters: 5
-  _updateDistanceInMeters: 5
-  _updateTimeInMilliSeconds: 500
+  _desiredAccuracyInMeters: 1
+  _updateDistanceInMeters: 1
+  _updateTimeInMilliSeconds: 50
   _userHeadingSmoothing: {fileID: 0}
   _deviceOrientationSmoothing: {fileID: 0}
   _editorDebuggingOnly:

--- a/FinderKeeper/Assets/Scripts/DistanceToPlayer.cs
+++ b/FinderKeeper/Assets/Scripts/DistanceToPlayer.cs
@@ -14,8 +14,14 @@ public class DistanceToPlayer : MonoBehaviour {
 	// Update is called once per frame
 	void Update () {
         GameObject player = GameObject.FindGameObjectWithTag("Player");
-        float dist = (gameObject.transform.position - player.transform.position).magnitude;
-        if (!ToggleARMode.isARActive && dist < 5.0f)
+
+        Vector3 playerPos = player.transform.localPosition;
+        Vector3 objectPos = gameObject.transform.localPosition;
+        Vector3 difference = new Vector3(objectPos.x - playerPos.x, 0, objectPos.z - playerPos.z);
+
+        float distance = difference.magnitude;
+
+        if (!ToggleARMode.isARActive && distance < 2.5f)
         {
             gameObject.transform.GetChild(0).gameObject.SetActive(true);
             gameObject.transform.GetChild(1).gameObject.SetActive(true);

--- a/FinderKeeper/Assets/Scripts/OverviewMap.cs
+++ b/FinderKeeper/Assets/Scripts/OverviewMap.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using UnityEngine;
 using Mapbox.Unity;
 using Mapbox.Unity.Map;
+using Mapbox.Unity.Location;
 using Mapbox.Unity.Utilities;
 using Mapbox.Utils;
 using Mapbox.Map;
 using Mapbox.Examples;
 
 public class OverviewMap : MonoBehaviour {
+    [SerializeField]
+    DeviceLocationProvider _locationProvider;
+
     [SerializeField]
     GameObject _mapCanvas;
 
@@ -71,7 +75,7 @@ public class OverviewMap : MonoBehaviour {
     }
 
     public void StorePlayerPosition () {
-        Transitions.playerPosition = _map.CenterLatitudeLongitude;
+        Transitions.playerPosition = _locationProvider.CurrentLocation.LatitudeLongitude;
         Transitions.isOverviewActive = true;
     }
 
@@ -104,6 +108,8 @@ public class OverviewMap : MonoBehaviour {
         if (!_cameraScript.isIsoCamera) {
             _cameraScript.Swap();
         }
+
+        _playerInstance.transform.localRotation = Transitions.playerRotation;
 	}
 
     public void DisableOverviewMap () {
@@ -277,8 +283,8 @@ public class OverviewMap : MonoBehaviour {
                     spawnedObject.transform.localScale = new Vector3(_markerSpawnScale, _markerSpawnScale, _markerSpawnScale);
                 }
             }
-
-            _playerInstance.transform.localPosition = Conversions.GeoToWorldPosition(_map.CenterLatitudeLongitude, _overviewMap.CenterMercator, _overviewMap.WorldRelativeScale).ToVector3xz();
+            
+            _playerInstance.transform.localPosition = Conversions.GeoToWorldPosition(_locationProvider.CurrentLocation.LatitudeLongitude, _overviewMap.CenterMercator, _overviewMap.WorldRelativeScale).ToVector3xz();
         }
 	}
 }


### PR DESCRIPTION
# Changes
- Reduced radar size to match new sight distance
- Fixed east/west rotation bug
- Updated item locations to ATC expo course
- Changed desired accuracy and update distance both to 1.0
- Changed location update time to 50ms
- Fixed item distance calculation to correctly ignore depth value
- Changed item sight distance to 2.5m (tested at the ATC expo course, all items are collectable)
- Fixed issue where the player position on the overview map did not match the current position on the main map **(Note: you will no longer see the player object on the overview map when testing in the editor. Build to device to see the player object. This is a quick fix for the expo)**
- Implemented a change so that the last known facing/rotation of the player object itself is respected in the overview map. This makes it easier to know which  circles you are currently facing etc. at a glance.